### PR TITLE
简化配置

### DIFF
--- a/Job.py
+++ b/Job.py
@@ -150,9 +150,9 @@ class ClusterJobs:
             {job_table}.time_end>{start} and \
             {job_table}.time_end<={end}".format(
                 start=start,end=end,
-                job_table = self.db_conf['job_table'],
-                qos_table = self.db_conf['qos_table'],
-                assoc_table = self.db_conf['assoc_table']
+                job_table = cluster_name + '_job_table',
+                qos_table = "qos_table",
+                assoc_table = cluster_name + '_assoc_table',
             )
 
         # TODO Add try except

--- a/README.md
+++ b/README.md
@@ -8,25 +8,22 @@ https://pkuhpc.github.io/SCOW/docs/mis/deployment/job_table
 
 配置内容在config.py中：
 
-| 字段名                      | 说明                     |
-| --------------------------- | ------------------------ |
-| cluster_name                | 集群名                   |
-| cluster_db_conf             | 集群slurm数据库信息      |
-| cluster_db_conf.host        | slurm数据库ip            |
-| cluster_db_conf.port        | slurm数据库端口          |
-| cluster_db_conf.user        | slurm数据库用户名        |
-| cluster_db_conf.passwd      | slurm数据库密码          |
-| cluster_db_conf.db          | slurm数据库名            |
-| cluster_db_conf.job_table   | slurm数据库作业表名      |
-| cluster_db_conf.qos_table   | slurm数据库qos表名       |
-| cluster_db_conf.assoc_table | slurm数据库用户关系表名  |
-| cluster_db_conf.gres_id     | slurm中gpu资源的id       |
-| mgt_db_conf                 | 存放作业的远端数据库配置 |
-| mgt_db_conf.host            | 源作业信息数据库ip       |
-| mgt_db_conf.port            | 源作业信息数据库端口     |
-| mgt_db_conf.user            | 源作业信息数据库用户名   |
-| mgt_db_conf.passwd          | 源作业信息数据库密码     |
-| mgt_db_conf.db              | 源作业信息数据库数据库名 |
+| 字段名                  | 说明                     |
+| ----------------------- | ------------------------ |
+| cluster_name            | slurm中集群的名称        |
+| cluster_db_conf         | 集群slurm数据库信息      |
+| cluster_db_conf.host    | slurm数据库ip            |
+| cluster_db_conf.port    | slurm数据库端口          |
+| cluster_db_conf.user    | slurm数据库用户名        |
+| cluster_db_conf.passwd  | slurm数据库密码          |
+| cluster_db_conf.db      | slurm数据库名            |
+| cluster_db_conf.gres_id | slurm中gpu资源的id       |
+| mgt_db_conf             | 存放作业的远端数据库配置 |
+| mgt_db_conf.host        | 源作业信息数据库ip       |
+| mgt_db_conf.port        | 源作业信息数据库端口     |
+| mgt_db_conf.user        | 源作业信息数据库用户名   |
+| mgt_db_conf.passwd      | 源作业信息数据库密码     |
+| mgt_db_conf.db          | 源作业信息数据库数据库名 |
 
 ## 运行说明
 

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-cluster_name="hpc01"
+cluster_name = 'hpc01'
 
 cluster_db_conf = {
     'host':'localhost',
@@ -6,9 +6,6 @@ cluster_db_conf = {
     'user':'username',
     'passwd':'passwd',
     'db':'slurm_acct_db',
-    'job_table':'cluster_job_table',
-    'qos_table':'qos_table',
-    'assoc_table':'cluster_assoc_table',
     'gres_id' : 1001
 }
 


### PR DESCRIPTION
job_table, qos_table和assoc_table的名字其实是确定的（qos_table一定叫qos_table）或者是可以有一定格式的（job_table和assoc_table的名字就是集群的名字+`_job_table`和`_assoc_table`），所以可以由脚本计算这些名字，不需要用户自己配置